### PR TITLE
Move ktor-client-core under api scope instead of implementation

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -23,7 +23,7 @@ kotlin {
                 implementation(libs.ktor.io)
                 implementation(libs.ktor.utils)
                 implementation(libs.ktor.client.websockets)
-                implementation(libs.ktor.client.core)
+                api(libs.ktor.client.core)
                 implementation(libs.ktor.client.resources)
                 implementation(libs.ktor.serialization.kotlinx.json)
                 implementation(libs.ktor.client.content.negotiation)


### PR DESCRIPTION
The `RestNode` class exposes a `Url` type from Ktor, which isn't available in the compile classpath when depending on core.

```
Cannot access class 'io.ktor.http.Url'. Check your module classpath for missing or conflicting dependencies
```

This change makes it available.