### PR TITLE
Fix load balancing heuristics, make load balancer public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ docs/
 
 .idea/artifacts
 !**/build/generated/
+core/gradle.properties

--- a/core/src/commonMain/kotlin/dev/schlaubi/lavakord/audio/internal/AbstractLavakord.kt
+++ b/core/src/commonMain/kotlin/dev/schlaubi/lavakord/audio/internal/AbstractLavakord.kt
@@ -132,8 +132,11 @@ public abstract class AbstractLavakord internal constructor(
     }
 
 
-    @Suppress("LeakingThis")
-    private val loadBalancer: LoadBalancer = LoadBalancer(options.loadBalancer.penaltyProviders, this)
+    /**
+     * The load balancer used to select nodes
+     */
+    @Suppress("LeakingThis", "MemberVisibilityCanBePrivate")
+    public val loadBalancer: LoadBalancer = LoadBalancer(options.loadBalancer.penaltyProviders, this)
 
     override val nodes: List<Node>
         get() = nodesMap.values.toList()

--- a/core/src/commonMain/kotlin/dev/schlaubi/lavakord/audio/internal/LoadBalancer.kt
+++ b/core/src/commonMain/kotlin/dev/schlaubi/lavakord/audio/internal/LoadBalancer.kt
@@ -38,11 +38,19 @@ public class LoadBalancer(
             playerPenalty = stats.playingPlayers
 
             cpuPenalty = 1.05.pow(100 * stats.cpu.systemLoad).toInt() * 10 - 10
-            if ((stats.frameStats != null) && stats.frameStats?.deficit != 1) {
+            val frameStats = stats.frameStats
+            if (frameStats != null) {
+                val frameDeficit = frameStats.deficit.coerceAtLeast(0).toFloat()
+                val frameNulls = frameStats.nulled.coerceAtLeast(0).toFloat()
+
                 deficitFramePenalty =
-                    (1.03.pow(((500f * (stats.frameStats?.deficit?.toFloat() ?: (0 / 3000f)))).toDouble()) * 600 - 600).toInt()
+                    (1.03.pow(
+                        ((500f * frameDeficit / 3000f)).toDouble()
+                    ) * 600 - 600).toInt()
                 nullFramePenalty =
-                    (1.03.pow(((500f * (stats.frameStats?.nulled?.toFloat() ?: (0 / 3000f)))).toDouble()) * 300 - 300).toInt() * 2
+                    (1.03.pow(
+                        ((500f * frameNulls / 3000f)).toDouble()
+                    ) * 300 - 300).toInt() * 2
             } else {
                 deficitFramePenalty = 0
                 nullFramePenalty = 0


### PR DESCRIPTION
This fixes the load balancing heuristics that were broken in https://github.com/kordlib/Lavalink.kt/commit/e6e6d8595822d1a2def0a4aea674cb516ef83f07#diff-d4a68aa4a4bea23eaf6314456bacd52dd00b3c0e9b7275669c3ac627eb6deefb

It also makes the load balancer publicly accessible, such that the functioning of the load balancer can be observed. This is a feature that I relied upon in my old Lavalink-Client. I fixed the heuristics on top of the first changes, and I was not inclined to go out of my way to separate them.

P.S: While cherry-picking, the master branch tripped me up. May want to delete that.